### PR TITLE
Make MMC devices uniform for VIcharak Boards

### DIFF
--- a/arch/arm/dts/rk3399-vaaman-u-boot.dtsi
+++ b/arch/arm/dts/rk3399-vaaman-u-boot.dtsi
@@ -5,8 +5,8 @@
 
 / {
 	aliases {
-		mmc0 = &sdmmc;
-		mmc1 = &sdhci;
+		mmc0 = &sdhci;
+		mmc1 = &sdmmc;
 		nvme0 = &pcie0;
 	};
 

--- a/include/configs/rockchip-common.h
+++ b/include/configs/rockchip-common.h
@@ -61,8 +61,8 @@
 /* First try to boot from SD (index 1), then eMMC (index 0) */
 #if CONFIG_IS_ENABLED(CMD_MMC)
 	#define BOOT_TARGET_MMC(func) \
-		func(MMC, mmc, 0) \
-		func(MMC, mmc, 1)
+		func(MMC, mmc, 1) \
+		func(MMC, mmc, 0)
 #else
 	#define BOOT_TARGET_MMC(func)
 #endif
@@ -158,10 +158,10 @@
 	"rkimg_bootdev=" \
 	"if nvme dev 0; then " \
 		"setenv devtype nvme; setenv devnum 0; echo Booting from NVMe;" \
-	"elif mmc dev 0 && rkimgtest mmc 0; then " \
-		"setenv devtype mmc; setenv devnum 0; echo Booting from SDcard;" \
-	"elif mmc dev 1; then " \
-		"setenv devtype mmc; setenv devnum 1; echo Booting from eMMC;" \
+	"elif mmc dev 1 && rkimgtest mmc 1; then " \
+		"setenv devtype mmc; setenv devnum 1; echo Booting from SDcard;" \
+	"elif mmc dev 0; then " \
+		"setenv devtype mmc; setenv devnum 0; echo Booting from eMMC;" \
 	"elif mtd_blk dev 0; then " \
 		"setenv devtype mtd; setenv devnum 0;" \
 	"elif mtd_blk dev 1; then " \


### PR DESCRIPTION
## Addresses non-uniformity of MMC device interfaces amongst Vicharak boards (Vaaman and Axon)
- This reverts commit `be148b6`.
   - Reason:
      * For Axon : 1.) MMC1 : SD,  2.) MMC0 : EMMC 
         > _issue_ : caused Axon to boot from EMMC even though SD card was inserted

      * For Vaaman: 1.) MMC0 : SD,  2.) MMC1 : EMMC
- Update `mmc` aliases for `Vaaman`.

### Note:
**DTS for Vaaman kernel is supposed to be amended for the same.**

